### PR TITLE
解决 &times 被转换为 x 的问题

### DIFF
--- a/aop/AopClient.php
+++ b/aop/AopClient.php
@@ -235,7 +235,7 @@ class AopClient
     public function pageExecuteUrl(AlipayRequest $request)
     {
         $queryParams = $this->build($request);
-        $url = $this->requester->getGateway().'?'.http_build_query($queryParams);
+        $url = $this->requester->getGateway().'?'.http_build_query($queryParams, '', '&amp;');
 
         return $url;
     }


### PR DESCRIPTION
当返回的链接中带有 &timestamp 参数时会被转义为 "x"，导致链接的参数不正确。